### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 ----------------
 
 
+* Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.
+
 * Drop support for Python 3.8.
 
 * Add support for Python 3.13.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,16 +4,14 @@ Changelog
 5.0 (unreleased)
 ----------------
 
+* Drop support for ``pkg_resources`` namespace and replace it with
+  PEP 420 native namespace.
+  Caution: This change requires to switch all packages in the `five`
+  namespace to versions using a PEP 420 namespace.
 
-* Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.
+* Drop support for Python 3.7, 3.8.
 
-* Drop support for Python 3.8.
-
-* Add support for Python 3.13.
-
-* Add support for Python 3.12.
-
-* Drop support for Python 3.7.
+* Add support for Python 3.12, 3.13.
 
 4.0 (2023-02-01)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
     keywords='zope five sitemanager',
-    packages=['five', 'five.localsitemanager'],
-    package_dir={'': 'src'},
-    namespace_packages=['five'],
     include_package_data=True,
     python_requires='>=3.9',
     install_requires=[

--- a/src/five/__init__.py
+++ b/src/five/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**

Built using https://github.com/zopefoundation/meta/pull/305
